### PR TITLE
feat(golden-layout): allow reorder of non-closable windows

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -320,6 +320,8 @@ export abstract class ContentItem extends EventEmitter {
     // (undocumented)
     static isComponentParentableItem(item: ContentItem): item is ComponentParentableItem;
     // (undocumented)
+    set isDragged(b: boolean);
+    // (undocumented)
     isGround: boolean;
     // (undocumented)
     get isInitialised(): boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -358,15 +358,13 @@ export class Header extends EventEmitter {
 
     /** @internal */
     private handleTabInitiatedDragStartEvent(x: number, y: number, dragListener: DragListener, componentItem: ComponentItem) {
-        if (!this._canRemoveComponent) {
-            dragListener.cancelDrag();
+        componentItem.isDragged = true;
+        if (this._componentDragStartEvent === undefined) {
+            throw new UnexpectedUndefinedError('HHTDSE22294');
         } else {
-            if (this._componentDragStartEvent === undefined) {
-                throw new UnexpectedUndefinedError('HHTDSE22294');
-            } else {
-                this._componentDragStartEvent(x, y, dragListener, componentItem);
-            }
+            this._componentDragStartEvent(x, y, dragListener, componentItem);
         }
+        componentItem.isDragged = false;
     }
 
     /** @internal */

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -35,7 +35,7 @@ export abstract class ContentItem extends EventEmitter {
     /** @internal */
     private _isInitialised;
     /** @internal */
-    private _isDragged: boolean = false;
+    private _isDragged = false;
 
     /** @internal */
     size: number;
@@ -57,7 +57,7 @@ export abstract class ContentItem extends EventEmitter {
     set id(value: string) { this._id = value; }
     set isDragged(b: boolean) {
         this._isDragged = b;
-        if (ContentItem.isComponentItem(this)) {
+        if (this.isComponent) {
             (this.parent as Stack).isDragged = b;
         }
     }

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -34,6 +34,8 @@ export abstract class ContentItem extends EventEmitter {
     private _throttledEvents: string[];
     /** @internal */
     private _isInitialised;
+    /** @internal */
+    private _isDragged: boolean = false;
 
     /** @internal */
     size: number;
@@ -53,6 +55,12 @@ export abstract class ContentItem extends EventEmitter {
     get type(): ItemType { return this._type; }
     get id(): string { return this._id; }
     set id(value: string) { this._id = value; }
+    set isDragged(b: boolean) {
+        this._isDragged = b;
+        if (ContentItem.isComponentItem(this)) {
+            (this.parent as Stack).isDragged = b;
+        }
+    }
     /** @internal */
     get popInParentIds(): string[] { return this._popInParentIds; }
     get parent(): ContentItem | null { return this._parent; }
@@ -156,7 +164,10 @@ export abstract class ContentItem extends EventEmitter {
             /**
              * If this was the last content item, remove this node as well
              */
-            if (!this.isGround && this._isClosable === true) {
+            if (!this.isGround && (
+                    this._isClosable === true
+                    /* Temporarily remove this so we can drag it to a different location */
+                    || this._isDragged)) {
                 if (this._parent === null) {
                     throw new UnexpectedNullError('CIUC00874');
                 } else {


### PR DESCRIPTION
📓  &nbsp; **Related Issue**

#2 

🤔  &nbsp; **What does this PR do?**

- Fixes issue where you cannot reorder an item if you have set its closable flag to be false

📑  &nbsp; **How should this be tested?**

Set some items to have `closable=false` and see that you can reorder them

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes. - N/A
- [ ] I have updated the project documentation to reflect my changes. - N/A
- [X] I have bumped the package version if I require this change to be published to npm.
