### PR TITLE
Fire `dragStart` and `dragStop` events  when user drags layout elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -47,6 +47,19 @@ export class DragProxy extends EventEmitter {
         this._dragListener.on('drag', (offsetX, offsetY, event) => this.onDrag(offsetX, offsetY, event));
         this._dragListener.on('dragStop', () => this.onDrop());
 
+        console.log("mw  - test")
+        console.log("mw", this._componentItem)
+        console.log("mw", this._componentItem.element) // TODO: Add listener to stop bubbling here?
+
+        console.log("mw", this._componentItem.element.children[0]);
+    const containedElements = Array.from(this._componentItem.element.children[0].children);
+
+        containedElements.forEach(element => {
+          if (customElements.get(element.localName)) {
+              element.dispatchEvent(new Event('dragStart'))
+            }
+        });
+
         this.createDragProxyElements(x, y);
 
         if (this._componentItem.parent === null) {
@@ -67,6 +80,12 @@ export class DragProxy extends EventEmitter {
         this.determineMinMaxXY();
         this._layoutManager.calculateItemAreas();
         this.setDropPosition(x, y);
+
+        containedElements.forEach(element => {
+          if (customElements.get(element.localName)) {
+              element.dispatchEvent(new Event('dragStop'))
+            }
+        });
     }
 
     /** Create Stack-like structure to contain the dragged component */

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -47,7 +47,7 @@ export class DragProxy extends EventEmitter {
         this._dragListener.on('drag', (offsetX, offsetY, event) => this.onDrag(offsetX, offsetY, event));
         this._dragListener.on('dragStop', () => this.onDrop());
 
-        this.fireEventsOnLayoutElements('dragStart')
+        this._componentItem.element.dispatchEvent(new Event('dragStart'))
         this.createDragProxyElements(x, y);
 
         if (this._componentItem.parent === null) {
@@ -69,21 +69,6 @@ export class DragProxy extends EventEmitter {
         this._layoutManager.calculateItemAreas();
         this.setDropPosition(x, y);
 
-    }
-
-    private fireEventsOnLayoutElements<T extends keyof EventEmitter.EventParamsMap>(event: T) {
-        let containedElements: Element[] = [];
-        try {
-            containedElements = Array.from(
-              this._componentItem.element?.children[0]?.children
-            );
-        } catch (error) {
-            // Let containedElements by an empty array if we fail to fill it
-        }
-
-        containedElements
-            .filter((e) => customElements.get(e.localName))
-            .forEach((e) => e.dispatchEvent(new Event(event)));
     }
 
     /** Create Stack-like structure to contain the dragged component */
@@ -202,7 +187,6 @@ export class DragProxy extends EventEmitter {
         }
 
         this._componentItem.exitDragMode();
-        this.fireEventsOnLayoutElements('dragStop')
 
         /*
          * Valid drop area found
@@ -242,6 +226,7 @@ export class DragProxy extends EventEmitter {
         this._element.remove();
 
         this._layoutManager.emit('itemDropped', this._componentItem);
+        this._componentItem.element.dispatchEvent(new Event('dragStop'))
 
         if (this._componentItemFocused && droppedComponentItem !== undefined) {
             droppedComponentItem.focus();

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -47,7 +47,7 @@ export class DragProxy extends EventEmitter {
         this._dragListener.on('drag', (offsetX, offsetY, event) => this.onDrag(offsetX, offsetY, event));
         this._dragListener.on('dragStop', () => this.onDrop());
 
-        this._componentItem.element.dispatchEvent(new Event('dragStart'))
+        this.fireEventToParent('dragStart')
         this.createDragProxyElements(x, y);
 
         if (this._componentItem.parent === null) {
@@ -68,7 +68,10 @@ export class DragProxy extends EventEmitter {
         this.determineMinMaxXY();
         this._layoutManager.calculateItemAreas();
         this.setDropPosition(x, y);
+    }
 
+    private fireEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T) {
+        this._componentItem.element.dispatchEvent(new Event(e))
     }
 
     /** Create Stack-like structure to contain the dragged component */
@@ -226,7 +229,7 @@ export class DragProxy extends EventEmitter {
         this._element.remove();
 
         this._layoutManager.emit('itemDropped', this._componentItem);
-        this._componentItem.element.dispatchEvent(new Event('dragStop'))
+        this.fireEventToParent('dragStart')
 
         if (this._componentItemFocused && droppedComponentItem !== undefined) {
             droppedComponentItem.focus();

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -47,7 +47,7 @@ export class DragProxy extends EventEmitter {
         this._dragListener.on('drag', (offsetX, offsetY, event) => this.onDrag(offsetX, offsetY, event));
         this._dragListener.on('dragStop', () => this.onDrop());
 
-        this.fireEventToParent('dragStart')
+        this.dispatchEventToParent('dragStart')
         this.createDragProxyElements(x, y);
 
         if (this._componentItem.parent === null) {
@@ -70,7 +70,7 @@ export class DragProxy extends EventEmitter {
         this.setDropPosition(x, y);
     }
 
-    private fireEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T) {
+    private dispatchEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T) {
         this._componentItem.element.dispatchEvent(new Event(e))
     }
 
@@ -229,7 +229,7 @@ export class DragProxy extends EventEmitter {
         this._element.remove();
 
         this._layoutManager.emit('itemDropped', this._componentItem);
-        this.fireEventToParent('dragStart')
+        this.dispatchEventToParent('dragStart')
 
         if (this._componentItemFocused && droppedComponentItem !== undefined) {
             droppedComponentItem.focus();


### PR DESCRIPTION
📓  &nbsp; **Related Issue**
#4 


🤔  &nbsp; **What does this PR do?**

- Fire `dragStart` event when the user starts dragging an item around in the layout
- Fire `dragStop` event when the user places a dragged item in a location in the layout
- Bumps the package to 2.7.0 as we've added a non-breaking feature

Add any sample images.

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes. - N/A
- [X] I have bumped the package version if I require this change to be published to npm.
