### PR TITLE
feat(golden-layout): emit closeButtonPressed event PTC-947

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -493,6 +493,8 @@ export namespace EventEmitter {
         // (undocumented)
         "close": NoParams;
         // (undocumented)
+        "closeButtonPressed": UnknownParams;
+        // (undocumented)
         "closed": NoParams;
         // (undocumented)
         "destroy": NoParams;
@@ -1175,6 +1177,8 @@ export abstract class LayoutManager extends EventEmitter {
     //
     // @internal @deprecated (undocumented)
     get transitionIndicator(): TransitionIndicator | null;
+    // @internal (undocumented)
+    tryDispatchEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T): void;
     // @internal (undocumented)
     abstract unbindComponent(container: ComponentContainer, virtual: boolean, component: ComponentContainer.Component | undefined): void;
     // @deprecated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -342,6 +342,7 @@ export class Header extends EventEmitter {
             if (this._componentRemoveEvent === undefined) {
                 throw new UnexpectedUndefinedError('HHTCE22294');
             } else {
+                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
                 this._componentRemoveEvent(componentItem);
             }
         }

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -260,6 +260,7 @@ export abstract class ContentItem extends EventEmitter {
         if (this._parent === null) {
             throw new UnexpectedNullError('CIR11110');
         } else {
+            this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
             this._parent.removeChild(this);
         }
     }

--- a/src/ts/items/stack.ts
+++ b/src/ts/items/stack.ts
@@ -334,12 +334,8 @@ export class Stack extends ComponentParentableItem {
             this._header.updateClosability();
         }
 
-        this.tryDispatchEventToParent('itemDestroyed');
+        this.layoutManager.tryDispatchEventToParent('itemDestroyed');
         this.emitStateChangedEvent();
-    }
-
-    private tryDispatchEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T) {
-        this.layoutManager?.groundItem?.element.dispatchEvent(new Event(e));
     }
 
     /**

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -1055,6 +1055,11 @@ export abstract class LayoutManager extends EventEmitter {
     }
 
     /** @internal */
+    tryDispatchEventToParent<T extends keyof EventEmitter.EventParamsMap>(e: T) {
+      this.container.dispatchEvent(new Event(e));
+    }
+
+    /** @internal */
     private createContentItemFromConfig(config: ResolvedItemConfig, parent: ContentItem): ContentItem {
         switch (config.type) {
             case ItemType.ground: throw new AssertError('LMCCIFC68871');

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -209,6 +209,7 @@ export namespace EventEmitter {
         "stackHeaderClick": ClickBubblingEventParam;
         "stackHeaderTouchStart": TouchStartBubblingEventParam;
         "userBroadcast": UnknownParams;
+        "closeButtonPressed": UnknownParams;
     }
 
     export type UnknownParams = unknown[];


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- emit `closeButtonPressed` event when either close button (on the tab or on the right hand side) are pressed

📑  &nbsp; **How should this be tested?**

- test via an integrated app

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have bumped the package version if I require this change to be published to npm.
