### PR TITLE
fix(golden-layout): fix closeButtonPressed being emit when layout is reloaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -178,7 +178,10 @@ export class Header extends EventEmitter {
          * Close button
          */
         if (this._configClosable) {
-            this._closeButton = new HeaderButton(this, this._closeLabel, DomConstants.ClassName.Close, () => closeEvent());
+            this._closeButton = new HeaderButton(this, this._closeLabel, DomConstants.ClassName.Close, () => {
+                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
+                closeEvent();
+            });
         }
 
         this.processTabDropdownActiveChanged();
@@ -342,6 +345,7 @@ export class Header extends EventEmitter {
             if (this._componentRemoveEvent === undefined) {
                 throw new UnexpectedUndefinedError('HHTCE22294');
             } else {
+        console.log("mw - handleTabInitiatedComponentRemoveEvent")
                 this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
                 this._componentRemoveEvent(componentItem);
             }

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -345,7 +345,6 @@ export class Header extends EventEmitter {
             if (this._componentRemoveEvent === undefined) {
                 throw new UnexpectedUndefinedError('HHTCE22294');
             } else {
-        console.log("mw - handleTabInitiatedComponentRemoveEvent")
                 this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
                 this._componentRemoveEvent(componentItem);
             }

--- a/src/ts/items/content-item.ts
+++ b/src/ts/items/content-item.ts
@@ -260,7 +260,6 @@ export abstract class ContentItem extends EventEmitter {
         if (this._parent === null) {
             throw new UnexpectedNullError('CIR11110');
         } else {
-            this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
             this._parent.removeChild(this);
         }
     }


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- Fix an issue with #7 that meant the event was emit when a layout was loaded too


✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have bumped the package version if I require this change to be published to npm.
