### PR TITLE
fix(golden-layout): fire button close event once the layout has finished updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -179,8 +179,8 @@ export class Header extends EventEmitter {
          */
         if (this._configClosable) {
             this._closeButton = new HeaderButton(this, this._closeLabel, DomConstants.ClassName.Close, () => {
-                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
                 closeEvent();
+                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
             });
         }
 
@@ -345,8 +345,8 @@ export class Header extends EventEmitter {
             if (this._componentRemoveEvent === undefined) {
                 throw new UnexpectedUndefinedError('HHTCE22294');
             } else {
-                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
                 this._componentRemoveEvent(componentItem);
+                this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
             }
         }
     }


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- Update the event emit from #7 to emit it after the layout has finished updating

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have bumped the package version if I require this change to be published to npm.
