### PR TITLE
fix(golden-layout): fire dragStop event rather than dragStart event 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/drag-proxy.ts
+++ b/src/ts/controls/drag-proxy.ts
@@ -229,7 +229,7 @@ export class DragProxy extends EventEmitter {
         this._element.remove();
 
         this._layoutManager.emit('itemDropped', this._componentItem);
-        this.dispatchEventToParent('dragStart')
+        this.dispatchEventToParent('dragStop');
 
         if (this._componentItemFocused && droppedComponentItem !== undefined) {
             droppedComponentItem.focus();


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- Fix to make sure we fire `dragStop` event when stopping drag rather than incorrectly firing `dragStart`

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have bumped the package version if I require this change to be published to npm.
