### PR TITLE
feat: fire additional close event before close action TPD-923

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -493,6 +493,8 @@ export namespace EventEmitter {
         // (undocumented)
         "close": NoParams;
         // (undocumented)
+        "closeButtonPre": UnknownParams;
+        // (undocumented)
         "closeButtonPressed": UnknownParams;
         // (undocumented)
         "closed": NoParams;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "A @genesis-community fork of the GoldenLayout multi-screen javascript Layout manager",
   "keywords": [
     "docking",

--- a/src/ts/controls/header.ts
+++ b/src/ts/controls/header.ts
@@ -179,6 +179,7 @@ export class Header extends EventEmitter {
          */
         if (this._configClosable) {
             this._closeButton = new HeaderButton(this, this._closeLabel, DomConstants.ClassName.Close, () => {
+                this.layoutManager.tryDispatchEventToParent('closeButtonPre');
                 closeEvent();
                 this.layoutManager.tryDispatchEventToParent('closeButtonPressed');
             });

--- a/src/ts/utils/event-emitter.ts
+++ b/src/ts/utils/event-emitter.ts
@@ -209,6 +209,7 @@ export namespace EventEmitter {
         "stackHeaderClick": ClickBubblingEventParam;
         "stackHeaderTouchStart": TouchStartBubblingEventParam;
         "userBroadcast": UnknownParams;
+        "closeButtonPre": UnknownParams;
         "closeButtonPressed": UnknownParams;
     }
 


### PR DESCRIPTION
📓  &nbsp; **Related Issue**

TPD-923

🤔  &nbsp; **What does this PR do?**

- Currently an event is fired when you click the close button and the contained element is closed
- Fire an additional event when the button is pressed, but before the contained element is closed

