### PR TITLE
feat: add LastStack and StackContainingComponentType LocationSelector types FUI-0

### DIFF
--- a/etc/golden-layout.api.md
+++ b/etc/golden-layout.api.md
@@ -1221,6 +1221,7 @@ export namespace LayoutManager {
         parentItem: ContentItem;
     }
     export interface LocationSelector {
+        componentType?: JsonValue;
         index?: number;
         typeId: LocationSelector.TypeId;
     }
@@ -1235,7 +1236,9 @@ export namespace LayoutManager {
             FirstStack = 2,
             FocusedItem = 0,
             FocusedStack = 1,
-            Root = 7
+            LastStack = 8,
+            Root = 7,
+            StackContainingComponentType = 9
         }
     }
     const defaultLocationSelectors: readonly LocationSelector[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@genesis-community/golden-layout",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@genesis-community/golden-layout",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-documenter": "^7.12.7",

--- a/src/ts/layout-manager.ts
+++ b/src/ts/layout-manager.ts
@@ -1692,6 +1692,36 @@ export abstract class LayoutManager extends EventEmitter {
                     return this.tryCreateLocationFromParentItem(parentItem, selectorIndex);
                 }
             }
+            case LayoutManager.LocationSelector.TypeId.LastStack: {
+                const stacks = this.getAllStacks();
+                if (stacks.length === 0) {
+                    return undefined;
+                } else {
+                    const parentItem = stacks[stacks.length - 1];
+                    return this.tryCreateLocationFromParentItem(parentItem, selectorIndex);
+                }
+            }
+            case LayoutManager.LocationSelector.TypeId.StackContainingComponentType: {
+                const componentType = selector.componentType;
+                if (componentType === undefined) {
+                    return undefined;
+                }
+                const allItems = this.getAllContentItems();
+                const stack = allItems.find(
+                    (item) =>
+                        item.type === ItemType.stack &&
+                        item.contentItems.some(
+                            (child) =>
+                                child.type === ItemType.component &&
+                                (child as ComponentItem).componentType === componentType,
+                        ),
+                ) as Stack | undefined;
+                if (stack === undefined) {
+                    return undefined;
+                } else {
+                    return this.tryCreateLocationFromParentItem(stack, selectorIndex);
+                }
+            }
             case LayoutManager.LocationSelector.TypeId.FirstRowOrColumn: {
                 let parentItem = this.findFirstContentItemType(ItemType.row);
                 if (parentItem !== undefined) {
@@ -1819,6 +1849,8 @@ export namespace LayoutManager {
         typeId: LocationSelector.TypeId;
         /** Used by algorithm to determine index in found ContentItem */
         index?: number;
+        /** Used by StackContainingComponentType to identify the target stack */
+        componentType?: JsonValue;
     }
 
     /** @public */
@@ -1840,6 +1872,10 @@ export namespace LayoutManager {
             Empty,
             /** Finds root if layout is empty, otherwise a child under root */
             Root,
+            /** Last stack found in layout (rightmost/bottommost in depth-first order) */
+            LastStack,
+            /** Stack that contains a component with the given componentType */
+            StackContainingComponentType,
         }
     }
 


### PR DESCRIPTION
📓 &nbsp; **Related Issue**

FUI-0 — companion to [foundation-ui PR #2265](https://github.com/genesislcap/foundation-ui/pull/2265) and [genesis-create PR #1429](https://github.com/genesislcap/genesis-create/pull/1429)

🤔 &nbsp; **What does this PR do?**

- Adds `componentType?: JsonValue` to the `LocationSelector` interface so callers can pass a component registration name alongside the selector
- Appends two new `TypeId` values at the **end** of the `const enum` (values 0–7 are untouched, preserving all existing inlined numeric references in compiled dist consumers):
  - `LastStack = 8` — finds the last/rightmost stack in the layout tree; useful for "always add to the end" patterns
  - `StackContainingComponentType = 9` — traverses all content items to find the stack containing a component with a matching `componentType`; enables placing a new panel as a tab next to an existing one without any knowledge of screen position
- Implements both new cases in `findLocation()` using the existing private `getAllStacks()` and `getAllContentItems()` helpers — no new public API surface

🚀 &nbsp; **Where should the reviewer start?**

`src/ts/layout-manager.ts`:
1. `LocationSelector` interface — new `componentType` field
2. `LocationSelector.TypeId` enum — two new values appended at the end
3. `findLocation()` — `case 8` and `case 9` implementations

📑 &nbsp; **How should this be tested?**

Call `addItemAtLocation(itemConfig, [{ typeId: 9, componentType: 'my-panel' }])` on a layout that contains a component registered as `'my-panel'` — the new item should be placed as a tab in the same stack, not as a new side-by-side column.

📷 &nbsp; **Samples**

N/A

✅ &nbsp; **Checklist**

- [x] I have tested my changes.
- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have bumped the package version if I require this change to be published to npm.
